### PR TITLE
Add rook-ceph.

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,6 +30,14 @@
       ],
       "datasourceTemplate": "helm"
     },
+    // regexManager to read and process rook-ceph CRD's
+    {
+      "fileMatch": ["cluster/crds/rook-ceph/.+\\.yaml$"],
+      "matchStrings": [
+        "registryUrl=(?<registryUrl>.*?) chart=(?<depName>.*?)\n *tag: (?<currentValue>.*)\n",
+      ],
+      "datasourceTemplate": "helm"
+    },
     // regexManager to read and process cert-manager CRD's
     {
       "fileMatch": [
@@ -49,6 +57,17 @@
         "registryUrl=(?<registryUrl>.*?) chart=(?<depName>.*?)\n *tag: v(?<currentValue>.*)\n"
       ],
       "datasourceTemplate": "helm"
+    },
+    // github release based crd
+    {
+      "fileMatch": [
+        "cluster/crds/external-snapshotter/.+\\.yaml$",
+        // "cluster/crds/external-dns/.+\\.yaml$"
+      ],
+      "matchStrings": [
+        "datasource=(?<datasource>.*?)\n *url: https:\/\/github\\.com\/(?<depName>.*?)\\.git\n *ref:\n *tag: (?<currentValue>.*)\n"
+      ],
+      "datasourceTemplate": "github-releases"
     },
   ],
   "packageRules": [
@@ -96,6 +115,23 @@
       "matchDatasources": ["helm"],
       "matchUpdateTypes": ["patch"],
       "labels": ["renovate/helm", "dep/patch"]
-    }
+    },
+    // group rook-ceph
+    {
+      "matchDatasources": ["helm", "docker"],
+      "matchPackagePatterns": ["^rook.ceph"],
+      "groupName": "rook-ceph",
+      "additionalBranchPrefix": "",
+    },
+    // group snapshot-controller
+    {
+      "matchDatasources": ["github-releases", "docker"],
+      "matchPackagePatterns": [
+        "external-snapshotter",
+        "snapshot-controller"
+      ],
+      "groupName": "external-snapshotter",
+      "additionalBranchPrefix": "",
+    },
   ]
 }

--- a/.taskfiles/ansible.yml
+++ b/.taskfiles/ansible.yml
@@ -52,6 +52,12 @@ tasks:
     cmds:
       - "ansible-playbook -i {{.ANSIBLE_INVENTORY_DIR}}/hosts.yml {{.ANSIBLE_PLAYBOOK_DIR}}/k3s-nuke.yml"
 
+  playbook:rook-ceph-nuke:
+    desc: Destroy rook-ceph disks
+    dir: provision/ansible
+    cmds:
+      - "ansible-playbook -i {{.ANSIBLE_INVENTORY_DIR}}/hosts.yml {{.ANSIBLE_PLAYBOOK_DIR}}/rook-ceph-nuke.yml"
+
   adhoc:ping:
     desc: Ping all the hosts
     dir: provision/ansible

--- a/cluster/core/kustomization.yaml
+++ b/cluster/core/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - kube-system
   - metallb-system
   - system-upgrade
+  - rook-ceph

--- a/cluster/core/namespaces/kustomization.yaml
+++ b/cluster/core/namespaces/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - cert-manager.yaml
   - metallb-system.yaml
   - networking.yaml
+  - rook-ceph.yaml

--- a/cluster/core/namespaces/rook-ceph.yaml
+++ b/cluster/core/namespaces/rook-ceph.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rook-ceph

--- a/cluster/core/rook-ceph/dashboard/ingress.yaml
+++ b/cluster/core/rook-ceph/dashboard/ingress.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: rook-ceph-mgr-dashboard
+  namespace: rook-ceph
+  annotations:
+    # external-dns.alpha.kubernetes.io/target: ${SECRET_DOMAIN}
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    # ingress.kubernetes.io/auth-url: https://auth.${SECRET_DOMAIN}/oauth2/auth
+    # nginx.ingress.kubernetes.io/auth-url: https://auth.${SECRET_DOMAIN}/oauth2/auth
+    # nginx.ingress.kubernetes.io/auth-signin: https://auth.${SECRET_DOMAIN}/oauth2/start
+    traefik.ingress.kubernetes.io/router.entrypoints: "websecure"
+    hajimari.io/enable: "true"
+    hajimari.io/icon: "weather-sunrise"
+  labels:
+    app.kubernetes.io/instance: rook-ceph-mgr-dashboard
+    app.kubernetes.io/name: rook-ceph-mgr-dashboard
+spec:
+  rules:
+    - host: rook.${SECRET_DOMAIN}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: rook-ceph-mgr-dashboard
+                port:
+                  name: http-dashboard
+  tls:
+    - hosts:
+        - rook.${SECRET_DOMAIN}
+      secretName: rook-tls

--- a/cluster/core/rook-ceph/dashboard/kustomization.yaml
+++ b/cluster/core/rook-ceph/dashboard/kustomization.yaml
@@ -1,6 +1,5 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cert-manager
-  - traefik
-  - rook-ceph
+  - ingress.yaml

--- a/cluster/core/rook-ceph/direct-mount/deployment.yaml
+++ b/cluster/core/rook-ceph/direct-mount/deployment.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rook-direct-mount
+  namespace: rook-ceph
+  labels:
+    app: rook-direct-mount
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rook-direct-mount
+  template:
+    metadata:
+      labels:
+        app: rook-direct-mount
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: rook-direct-mount
+          image: rook/ceph:v1.7.7
+          command: ["/tini"]
+          args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ROOK_CEPH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: rook-ceph-mon
+                  key: ceph-username
+            - name: ROOK_CEPH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: rook-ceph-mon
+                  key: ceph-secret
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /dev
+              name: dev
+            - mountPath: /sys/bus
+              name: sysbus
+            - mountPath: /lib/modules
+              name: libmodules
+            - name: mon-endpoint-volume
+              mountPath: /etc/rook
+      # if hostNetwork: false, the "rbd map" command hangs,
+      # see https://github.com/rook/rook/issues/2021
+      hostNetwork: true
+      volumes:
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: sysbus
+          hostPath:
+            path: /sys/bus
+        - name: libmodules
+          hostPath:
+            path: /lib/modules
+        - name: mon-endpoint-volume
+          configMap:
+            name: rook-ceph-mon-endpoints
+            items:
+              - key: data
+                path: mon-endpoints

--- a/cluster/core/rook-ceph/direct-mount/kustomization.yaml
+++ b/cluster/core/rook-ceph/direct-mount/kustomization.yaml
@@ -1,6 +1,5 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cert-manager
-  - traefik
-  - rook-ceph
+  - deployment.yaml

--- a/cluster/core/rook-ceph/helmrelease.yaml
+++ b/cluster/core/rook-ceph/helmrelease.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph
+spec:
+  interval: 10m
+  chart:
+    spec:
+      # renovate: registryUrl=https://charts.rook.io/release
+      chart: rook-ceph
+      version: v1.7.7
+      sourceRef:
+        kind: HelmRepository
+        name: rook
+        namespace: flux-system
+  values:
+    crds:
+      enabled: false

--- a/cluster/core/rook-ceph/kustomization.yaml
+++ b/cluster/core/rook-ceph/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - storage
+  - dashboard
+  - toolbox
+  - direct-mount
+  - monitoring
+  - snapshot-controller

--- a/cluster/core/rook-ceph/monitoring/csi-metrics-servicemonitor.yaml
+++ b/cluster/core/rook-ceph/monitoring/csi-metrics-servicemonitor.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: csi-metrics
+  namespace: rook-ceph
+  labels:
+    team: rook
+spec:
+  namespaceSelector:
+    matchNames:
+      - rook-ceph
+  selector:
+    matchLabels:
+      app: csi-metrics
+  endpoints:
+    - port: csi-http-metrics
+      path: /metrics
+      interval: 5s

--- a/cluster/core/rook-ceph/monitoring/kustomization.yaml
+++ b/cluster/core/rook-ceph/monitoring/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - csi-metrics-servicemonitor.yaml
+  - rook-ceph-mgr-servicemonitor.yaml

--- a/cluster/core/rook-ceph/monitoring/rook-ceph-mgr-servicemonitor.yaml
+++ b/cluster/core/rook-ceph/monitoring/rook-ceph-mgr-servicemonitor.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: rook-ceph-mgr
+  namespace: rook-ceph
+  labels:
+    team: rook
+spec:
+  namespaceSelector:
+    matchNames:
+      - rook-ceph
+  selector:
+    matchLabels:
+      app: rook-ceph-mgr
+      rook_cluster: rook-ceph
+      ceph_daemon_id: a
+  endpoints:
+    - port: http-metrics
+      path: /metrics
+      interval: 5s

--- a/cluster/core/rook-ceph/snapshot-controller/deployment.yaml
+++ b/cluster/core/rook-ceph/snapshot-controller/deployment.yaml
@@ -1,0 +1,33 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: snapshot-controller
+  namespace: rook-ceph
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: snapshot-controller
+  # the snapshot controller won't be marked as ready if the v1 CRDs are unavailable
+  # in #504 the snapshot-controller will exit after around 7.5 seconds if it
+  # can't find the v1 CRDs so this value should be greater than that
+  minReadySeconds: 15
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: snapshot-controller
+    spec:
+      serviceAccount: snapshot-controller
+      containers:
+        - name: snapshot-controller
+          image: k8s.gcr.io/sig-storage/snapshot-controller:v4.2.1
+          args:
+            - "--v=5"
+            - "--leader-election=true"
+          imagePullPolicy: IfNotPresent

--- a/cluster/core/rook-ceph/snapshot-controller/kustomization.yaml
+++ b/cluster/core/rook-ceph/snapshot-controller/kustomization.yaml
@@ -1,6 +1,6 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cert-manager
-  - traefik
-  - rook-ceph
+  - rbac.yaml
+  - deployment.yaml

--- a/cluster/core/rook-ceph/snapshot-controller/rbac.yaml
+++ b/cluster/core/rook-ceph/snapshot-controller/rbac.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapshot-controller
+  namespace: rook-ceph
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-controller-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-controller-role
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-controller
+    namespace: rook-ceph
+roleRef:
+  kind: ClusterRole
+  name: snapshot-controller-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-controller-leaderelection
+  namespace: rook-ceph
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-controller-leaderelection
+  namespace: rook-ceph
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-controller
+roleRef:
+  kind: Role
+  name: snapshot-controller-leaderelection
+  apiGroup: rbac.authorization.k8s.io

--- a/cluster/core/rook-ceph/storage/cephblockpool.yaml
+++ b/cluster/core/rook-ceph/storage/cephblockpool.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: replicapool
+  namespace: rook-ceph
+spec:
+  failureDomain: host
+  replicated:
+    size: 3
+    requireSafeReplicaSize: true

--- a/cluster/core/rook-ceph/storage/cephcluster.yaml
+++ b/cluster/core/rook-ceph/storage/cephcluster.yaml
@@ -1,0 +1,78 @@
+---
+# based on https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/ceph/cluster.yaml
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph
+spec:
+  cephVersion:
+    image: quay.io/ceph/ceph:v16.2.6
+    allowUnsupported: false
+  dataDirHostPath: /var/lib/rook
+  skipUpgradeChecks: false
+  continueUpgradeAfterChecksEvenIfNotHealthy: false
+  waitTimeoutForHealthyOSDInMinutes: 10
+  mon:
+    count: 3
+    allowMultiplePerNode: false
+  mgr:
+    count: 1
+    modules:
+      - name: pg_autoscaler
+        enabled: true
+  dashboard:
+    enabled: true
+    port: 7000
+    ssl: false
+  monitoring:
+    enabled: true
+  crashCollector:
+    disable: false
+  cleanupPolicy:
+    # set to "yes-really-destroy-data" to destroy data on uninstall
+    confirmation: ""
+    sanitizeDisks:
+      method: quick
+      dataSource: zero
+      iteration: 1
+    allowUninstallWithVolumes: false
+  removeOSDsIfOutAndSafeToRemove: false
+  storage:
+    useAllNodes: false
+    useAllDevices: false
+    config:
+    nodes:
+      - name: k8s-node-1
+        devices:
+          - name: nvme0n1
+      - name: k8s-node-2
+        devices:
+          - name: nvme0n1
+      - name: k8s-node-3
+        devices:
+          - name: nvme0n1
+  disruptionManagement:
+    managePodBudgets: true
+    osdMaintenanceTimeout: 30
+    pgHealthCheckTimeout: 0
+    manageMachineDisruptionBudgets: false
+    machineDisruptionBudgetNamespace: openshift-machine-api
+  healthCheck:
+    daemonHealth:
+      mon:
+        disabled: false
+        interval: 45s
+      osd:
+        disabled: false
+        interval: 60s
+      status:
+        disabled: false
+        interval: 60s
+    livenessProbe:
+      mon:
+        disabled: false
+      mgr:
+        disabled: false
+      osd:
+        disabled: false

--- a/cluster/core/rook-ceph/storage/kustomization.yaml
+++ b/cluster/core/rook-ceph/storage/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cephblockpool.yaml
+  - cephcluster.yaml
+  - storageclass.yaml
+  - volumesnapshotclass.yaml

--- a/cluster/core/rook-ceph/storage/storageclass.yaml
+++ b/cluster/core/rook-ceph/storage/storageclass.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rook-ceph-block
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: rook-ceph.rbd.csi.ceph.com
+parameters:
+  clusterID: rook-ceph
+  pool: replicapool
+  imageFormat: "2"
+  imageFeatures: layering
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+  csi.storage.k8s.io/fstype: ext4
+allowVolumeExpansion: true
+reclaimPolicy: Delete

--- a/cluster/core/rook-ceph/storage/volumesnapshotclass.yaml
+++ b/cluster/core/rook-ceph/storage/volumesnapshotclass.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-rbdplugin-snapclass
+driver: rook-ceph.rbd.csi.ceph.com
+parameters:
+  clusterID: rook-ceph
+  csi.storage.k8s.io/snapshotter-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/snapshotter-secret-namespace: rook-ceph
+deletionPolicy: Delete

--- a/cluster/core/rook-ceph/toolbox/deployment.yaml
+++ b/cluster/core/rook-ceph/toolbox/deployment.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rook-ceph-tools
+  namespace: rook-ceph
+  labels:
+    app: rook-ceph-tools
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rook-ceph-tools
+  template:
+    metadata:
+      labels:
+        app: rook-ceph-tools
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: rook-ceph-tools
+          image: rook/ceph:v1.7.7
+          command: ["/tini"]
+          args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ROOK_CEPH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: rook-ceph-mon
+                  key: ceph-username
+            - name: ROOK_CEPH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: rook-ceph-mon
+                  key: ceph-secret
+          volumeMounts:
+            - mountPath: /etc/ceph
+              name: ceph-config
+            - name: mon-endpoint-volume
+              mountPath: /etc/rook
+      volumes:
+        - name: mon-endpoint-volume
+          configMap:
+            name: rook-ceph-mon-endpoints
+            items:
+              - key: data
+                path: mon-endpoints
+        - name: ceph-config
+          emptyDir: {}
+      tolerations:
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 5

--- a/cluster/core/rook-ceph/toolbox/kustomization.yaml
+++ b/cluster/core/rook-ceph/toolbox/kustomization.yaml
@@ -1,6 +1,5 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cert-manager
-  - traefik
-  - rook-ceph
+  - deployment.yaml

--- a/cluster/crds/rook-ceph/crds.yaml
+++ b/cluster/crds/rook-ceph/crds.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: rook-ceph-crds
+  namespace: flux-system
+spec:
+  interval: 30m
+  url: https://github.com/rook/rook.git
+  ref:
+    # renovate: registryUrl=https://charts.rook.io/release chart=rook-ceph
+    tag: v1.7.7
+  ignore: |
+    # exclude all
+    /*
+    # include crds
+    !/cluster/examples/kubernetes/ceph/crds.yaml
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+kind: Kustomization
+metadata:
+  name: rook-ceph-crds
+  namespace: flux-system
+spec:
+  interval: 30m
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: rook-ceph-crds

--- a/cluster/crds/rook-ceph/kustomization.yaml
+++ b/cluster/crds/rook-ceph/kustomization.yaml
@@ -1,6 +1,5 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cert-manager
-  - traefik
-  - rook-ceph
+  - crds.yaml

--- a/provision/ansible/playbooks/rook-ceph-nuke.yaml
+++ b/provision/ansible/playbooks/rook-ceph-nuke.yaml
@@ -1,0 +1,64 @@
+---
+- hosts:
+    - master
+    - worker
+  vars_prompt:
+    name: nuke_confirmation
+    prompt: This will DESTROY rook-ceph disks. Do you wish to continue? [Y/n]
+    default: n
+    private: false
+  any_errors_fatal: true
+  pre_tasks:
+    - name: check confirmation
+      fail:
+        msg: Abort.
+      when: nuke_confirmation != "Y"
+
+  tasks:
+    - name: remove /var/lib/rook
+      file:
+        state: absent
+        path: /var/lib/rook
+      become: true
+      when: rook_ceph_enabled is defined and rook_ceph_enabled
+
+    - name: zap the drives
+      shell: sgdisk --zap-all {{ item }} || true  # noqa 306
+      loop: "{{ rook_ceph_devices }}"
+      become: true
+      when: rook_ceph_enabled is defined and rook_ceph_enabled
+
+    - name: remove lvm partitions
+      shell: "{{ item }}"  # noqa 305
+      loop:
+        - ls /dev/mapper/ceph--* | xargs -I% -- fuser --kill %
+        - ls /dev/mapper/ceph--* | xargs -I% -- dmsetup clear %
+        - ls /dev/mapper/ceph--* | xargs -I% -- dmsetup remove -f %
+        - ls /dev/mapper/ceph--* | xargs -I% -- rm -rf %
+      become: true
+      when: rook_ceph_enabled is defined and rook_ceph_enabled
+
+    - name: look for remaining /dev/ceph-* directories
+      find:
+        paths: /dev
+        patterns: ceph-*
+        file_type: directory
+      become: true
+      register: remaining_directories
+      when: rook_ceph_enabled is defined and rook_ceph_enabled
+
+    - name: remove directory clutter
+      file:
+        path: "{{ item.path }}"
+        state: absent
+      become: true
+      loop: "{{ remaining_directories.files }}"
+      loop_control:
+        label: "{{ item.path }}"
+      when: rook_ceph_enabled is defined and rook_ceph_enabled
+
+    - name: wipe the block device
+      command: wipefs -af {{ item }}
+      become: true
+      loop: "{{ rook_ceph_devices }}"
+      when: rook_ceph_enabled is defined and rook_ceph_enabled


### PR DESCRIPTION
**Description of the change**

Using code from https://github.com/Diaoul/home-ops to see if we can get rook-ceph up and running. This should setup 1 instance per node. It is currently setup for 3 nodes and all nodes are using matching nvme1 drives.

**Benefits**

We will have storage that works across nodes. 

**Possible drawbacks**

The template above has diverged from the original template, they use Nginx instead of Traefik and rely on external-dns

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

Nothing yet
