### PR TITLE
Temporarily disable monitoring for rook-ceph

### DIFF
--- a/cluster/core/rook-ceph/kustomization.yaml
+++ b/cluster/core/rook-ceph/kustomization.yaml
@@ -7,5 +7,5 @@ resources:
   - dashboard
   - toolbox
   - direct-mount
-  - monitoring
+  # - monitoring
   - snapshot-controller


### PR DESCRIPTION
**Description of the change**

Temporarily disable monitoring

**Benefits**

It should make rook-ceph work, we can't setup the monitoring stuff until we have a volume to put it on.

**Possible drawbacks**

We won't have monitoring.

**Applicable issues**

The previous pull request is related.

**Additional information**

None yet.
